### PR TITLE
Add configuration schemas and loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A data-driven Paper plugin that delivers an extraction-style raid loop for Minec
 - **Reset/Cleanup:** restore players to lobby, cancel tasks, reset containers, and clear entities/effects.
 
 ## Repository Status
-Gradle scaffolding is in place for a cloud-safe build. See `TODO.md` for the implementation roadmap that keeps `./gradlew clean build` passing during the cloud phase.
+Gradle scaffolding is in place for a cloud-safe build, plugin metadata (`plugin.yml`) plus the base `RaidExtractionPlugin` lifecycle have been stubbed, and Phase 2 configuration files now load via `ConfigManager`. See `TODO.md` for the implementation roadmap that keeps `./gradlew clean build` passing during the cloud phase.
 
 ## Build & Requirements
 - Java 21 toolchain (configured in Gradle).
@@ -81,9 +81,10 @@ raidextraction/
     config.yml
     raids.yml
     loot_tables.yml
+    director.yml
 ```
 
-## Config Files (planned)
+## Config Files
 - **config.yml:** global settings (debug flags, lobby spawn, defaults).
 - **raids.yml:** raid definitions (world, lobby spawn, raid region, player spawns, evac zones, duration).
 - **loot_tables.yml:** named loot tables with weighted entries (material, amount range, enchantments later).

--- a/TODO.md
+++ b/TODO.md
@@ -13,12 +13,12 @@ This TODO tracks the cloud-safe implementation path for the Raid Extraction Pape
 - [x] Create `.gitignore`, LICENSE (MIT), and baseline README.
 
 ## Phase 1 — Base Plugin & Metadata
-- [ ] Add `plugin.yml` with commands (`raid`, `stash`, `raidadmin`) and permissions (`raid.user`, `raid.admin`).
-- [ ] Implement `RaidExtractionPlugin` lifecycle with logging hooks and configuration initialization.
+- [x] Add `plugin.yml` with commands (`raid`, `stash`, `raidadmin`) and permissions (`raid.user`, `raid.admin`).
+- [x] Implement `RaidExtractionPlugin` lifecycle with logging hooks and configuration initialization.
 
 ## Phase 2 — Config Schemas & Loader
-- [ ] Add `config.yml`, `raids.yml`, `loot_tables.yml`, and `director.yml` resource files with comments.
-- [ ] Implement `ConfigManager` plus models (`RaidDefinition`, `EvacZoneDefinition`, `LootTableDefinition`, `LootEntry`) and soft validation.
+- [x] Add `config.yml`, `raids.yml`, `loot_tables.yml`, and `director.yml` resource files with comments.
+- [x] Implement `ConfigManager` plus models (`RaidDefinition`, `EvacZoneDefinition`, `LootTableDefinition`, `LootEntry`) and soft validation.
 
 ## Phase 3 — Core Logic Skeleton
 - [ ] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.

--- a/src/main/java/com/raidextraction/RaidExtractionPlugin.java
+++ b/src/main/java/com/raidextraction/RaidExtractionPlugin.java
@@ -1,0 +1,55 @@
+package com.raidextraction;
+
+import com.raidextraction.config.ConfigManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Base plugin entrypoint for the Raid Extraction Paper plugin.
+ */
+public final class RaidExtractionPlugin extends JavaPlugin {
+
+    private ConfigManager configManager;
+
+    @Override
+    public void onLoad() {
+        getLogger().info("RaidExtraction plugin loading (preparing data folder and config scaffolding).");
+        prepareDataFolder();
+    }
+
+    @Override
+    public void onEnable() {
+        getLogger().info("RaidExtraction plugin enabling (commands and listeners will register in later phases).");
+        prepareDataFolder();
+        initializeConfigurationScaffolding();
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("RaidExtraction plugin disabling. Cleaning up resources.");
+    }
+
+    public ConfigManager getConfigManager() {
+        return configManager;
+    }
+
+    private void prepareDataFolder() {
+        if (!getDataFolder().exists() && getDataFolder().mkdirs()) {
+            getLogger().info("Created plugin data folder at " + getDataFolder().getAbsolutePath());
+        }
+    }
+
+    private void initializeConfigurationScaffolding() {
+        configManager = new ConfigManager(this);
+        configManager.load();
+
+        if (configManager.getRaidDefinitions().isEmpty()) {
+            getLogger().warning("No raid definitions found; add entries to raids.yml to enable raid creation.");
+        }
+
+        if (configManager.getLootTableDefinitions().isEmpty()) {
+            getLogger().warning("No loot tables found; add entries to loot_tables.yml to enable loot rolls.");
+        }
+
+        getLogger().info("Configuration scaffolding ready; raid and loot definitions loaded for future phases.");
+    }
+}

--- a/src/main/java/com/raidextraction/config/ConfigManager.java
+++ b/src/main/java/com/raidextraction/config/ConfigManager.java
@@ -1,0 +1,196 @@
+package com.raidextraction.config;
+
+import com.raidextraction.config.model.EvacZoneDefinition;
+import com.raidextraction.config.model.LootEntry;
+import com.raidextraction.config.model.LootTableDefinition;
+import com.raidextraction.config.model.RaidDefinition;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public final class ConfigManager {
+    private final JavaPlugin plugin;
+    private final Logger logger;
+
+    private FileConfiguration mainConfig;
+    private FileConfiguration raidsConfig;
+    private FileConfiguration lootTablesConfig;
+    private FileConfiguration directorConfig;
+
+    private Map<String, RaidDefinition> raidDefinitions = Collections.emptyMap();
+    private Map<String, LootTableDefinition> lootTableDefinitions = Collections.emptyMap();
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.logger = plugin.getLogger();
+    }
+
+    public void load() {
+        ensureResource("config.yml");
+        ensureResource("raids.yml");
+        ensureResource("loot_tables.yml");
+        ensureResource("director.yml");
+
+        mainConfig = loadConfig("config.yml");
+        raidsConfig = loadConfig("raids.yml");
+        lootTablesConfig = loadConfig("loot_tables.yml");
+        directorConfig = loadConfig("director.yml");
+
+        lootTableDefinitions = parseLootTables();
+        raidDefinitions = parseRaids();
+    }
+
+    public FileConfiguration getMainConfig() {
+        return mainConfig;
+    }
+
+    public FileConfiguration getDirectorConfig() {
+        return directorConfig;
+    }
+
+    public Map<String, RaidDefinition> getRaidDefinitions() {
+        return raidDefinitions;
+    }
+
+    public Map<String, LootTableDefinition> getLootTableDefinitions() {
+        return lootTableDefinitions;
+    }
+
+    private void ensureResource(String resourceName) {
+        File target = new File(plugin.getDataFolder(), resourceName);
+        if (!target.exists()) {
+            plugin.saveResource(resourceName, false);
+            logger.info("Saved default " + resourceName + " to data folder.");
+        }
+    }
+
+    private FileConfiguration loadConfig(String fileName) {
+        File file = new File(plugin.getDataFolder(), fileName);
+        return YamlConfiguration.loadConfiguration(file);
+    }
+
+    private Map<String, LootTableDefinition> parseLootTables() {
+        ConfigurationSection section = lootTablesConfig.getConfigurationSection("loot_tables");
+        if (section == null) {
+            logger.warning("No loot_tables section found in loot_tables.yml. Add at least one table.");
+            return Collections.emptyMap();
+        }
+
+        Map<String, LootTableDefinition> tables = new HashMap<>();
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection tableSection = section.getConfigurationSection(id);
+            if (tableSection == null) {
+                continue;
+            }
+
+            List<LootEntry> entries = new ArrayList<>();
+            List<Map<?, ?>> entryMaps = tableSection.getMapList("entries");
+            for (Map<?, ?> entryMap : entryMaps) {
+                LootEntry entry = new LootEntry(
+                        asString(entryMap.get("id"), ""),
+                        asString(entryMap.get("material"), ""),
+                        asInt(entryMap.get("weight"), 1),
+                        asInt(entryMap.get("min_amount"), 1),
+                        asInt(entryMap.get("max_amount"), 1)
+                );
+                if (!entry.isValid()) {
+                    logger.warning("Invalid loot entry in table " + id + ": " + entry);
+                    continue;
+                }
+                entries.add(entry);
+            }
+
+            LootTableDefinition definition = new LootTableDefinition(id, entries);
+            if (!definition.isValid()) {
+                logger.warning("Loot table " + id + " is missing required fields or has no valid entries.");
+                continue;
+            }
+            tables.put(id, definition);
+        }
+
+        logger.info("Loaded " + tables.size() + " loot table(s).");
+        return tables;
+    }
+
+    private Map<String, RaidDefinition> parseRaids() {
+        ConfigurationSection section = raidsConfig.getConfigurationSection("raids");
+        if (section == null) {
+            logger.warning("No raids section found in raids.yml. Add at least one raid definition.");
+            return Collections.emptyMap();
+        }
+
+        Map<String, RaidDefinition> raids = new HashMap<>();
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection raidSection = section.getConfigurationSection(id);
+            if (raidSection == null) {
+                continue;
+            }
+
+            List<EvacZoneDefinition> evacZones = parseEvacZones(raidSection);
+            RaidDefinition definition = new RaidDefinition(
+                    id,
+                    raidSection.getString("world", "world"),
+                    raidSection.getInt("min_players", 1),
+                    raidSection.getInt("max_players", 4),
+                    raidSection.getInt("duration_seconds", 900),
+                    raidSection.getString("loot_table", "default"),
+                    evacZones
+            );
+
+            if (!definition.isValid()) {
+                logger.warning("Raid " + id + " is missing required fields or has invalid limits.");
+                continue;
+            }
+
+            if (!evacZones.isEmpty() && evacZones.stream().noneMatch(EvacZoneDefinition::isValid)) {
+                logger.warning("Raid " + id + " has evac zones defined but none are valid.");
+            }
+
+            raids.put(id, definition);
+        }
+
+        logger.info("Loaded " + raids.size() + " raid definition(s).");
+        return raids;
+    }
+
+    private List<EvacZoneDefinition> parseEvacZones(ConfigurationSection raidSection) {
+        List<EvacZoneDefinition> zones = new ArrayList<>();
+        List<Map<?, ?>> zoneMaps = raidSection.getMapList("evac_zones");
+        for (Map<?, ?> map : zoneMaps) {
+            EvacZoneDefinition zone = new EvacZoneDefinition(
+                    asString(map.get("name"), ""),
+                    asString(map.get("world"), raidSection.getString("world", "world")),
+                    asInt(map.get("x"), 0),
+                    asInt(map.get("y"), 64),
+                    asInt(map.get("z"), 0),
+                    asInt(map.get("radius"), 6)
+            );
+            if (!zone.isValid()) {
+                logger.warning("Invalid evac zone in raid " + raidSection.getName() + ": " + zone);
+                continue;
+            }
+            zones.add(zone);
+        }
+        return zones;
+    }
+
+    private int asInt(Object value, int fallback) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return fallback;
+    }
+
+    private String asString(Object value, String fallback) {
+        return value != null ? value.toString() : fallback;
+    }
+}

--- a/src/main/java/com/raidextraction/config/model/EvacZoneDefinition.java
+++ b/src/main/java/com/raidextraction/config/model/EvacZoneDefinition.java
@@ -1,0 +1,14 @@
+package com.raidextraction.config.model;
+
+public record EvacZoneDefinition(
+        String name,
+        String world,
+        int x,
+        int y,
+        int z,
+        int radius
+) {
+    public boolean isValid() {
+        return world != null && !world.isEmpty() && radius > 0;
+    }
+}

--- a/src/main/java/com/raidextraction/config/model/LootEntry.java
+++ b/src/main/java/com/raidextraction/config/model/LootEntry.java
@@ -1,0 +1,13 @@
+package com.raidextraction.config.model;
+
+public record LootEntry(
+        String id,
+        String material,
+        int weight,
+        int minAmount,
+        int maxAmount
+) {
+    public boolean isValid() {
+        return material != null && !material.isEmpty() && weight > 0 && maxAmount >= minAmount && minAmount > 0;
+    }
+}

--- a/src/main/java/com/raidextraction/config/model/LootTableDefinition.java
+++ b/src/main/java/com/raidextraction/config/model/LootTableDefinition.java
@@ -1,0 +1,12 @@
+package com.raidextraction.config.model;
+
+import java.util.List;
+
+public record LootTableDefinition(
+        String id,
+        List<LootEntry> entries
+) {
+    public boolean isValid() {
+        return id != null && !id.isEmpty() && entries != null && !entries.isEmpty() && entries.stream().allMatch(LootEntry::isValid);
+    }
+}

--- a/src/main/java/com/raidextraction/config/model/RaidDefinition.java
+++ b/src/main/java/com/raidextraction/config/model/RaidDefinition.java
@@ -1,0 +1,17 @@
+package com.raidextraction.config.model;
+
+import java.util.List;
+
+public record RaidDefinition(
+        String id,
+        String world,
+        int minPlayers,
+        int maxPlayers,
+        int durationSeconds,
+        String lootTableId,
+        List<EvacZoneDefinition> evacZones
+) {
+    public boolean isValid() {
+        return world != null && !world.isEmpty() && minPlayers > 0 && maxPlayers >= minPlayers && durationSeconds > 0 && lootTableId != null && !lootTableId.isEmpty();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+# Global settings for Raid Extraction. Values here provide defaults for other configs.
+# Later phases will add lobby spawn, queue sizing, and matchmaking tuning.
+
+debug: false
+lobby_world: world
+announce_start: true

--- a/src/main/resources/director.yml
+++ b/src/main/resources/director.yml
@@ -1,0 +1,7 @@
+# Director settings for raid pacing and events. Placeholder until threat curves are implemented.
+# Example knobs: difficulty multiplier, ambient events, and spawn pacing overrides.
+
+director:
+  enabled: false
+  difficulty_scale: 1.0
+  notes: "Configure encounter pacing in a future phase."

--- a/src/main/resources/loot_tables.yml
+++ b/src/main/resources/loot_tables.yml
@@ -1,0 +1,19 @@
+# Loot tables with weighted entries. Later phases will convert materials into ItemStacks and neutral data.
+loot_tables:
+  starter_cache:
+    entries:
+      - id: medical_bandage
+        material: PAPER
+        weight: 10
+        min_amount: 1
+        max_amount: 3
+      - id: rusty_sword
+        material: IRON_SWORD
+        weight: 5
+        min_amount: 1
+        max_amount: 1
+      - id: canned_food
+        material: BREAD
+        weight: 12
+        min_amount: 2
+        max_amount: 4

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,25 @@
+name: RaidExtraction
+main: com.raidextraction.RaidExtractionPlugin
+version: 0.0.1-SNAPSHOT
+description: Data-driven Paper plugin providing a raid-to-extraction gameplay loop.
+api-version: "1.21"
+commands:
+  raid:
+    description: Join or check raid queues.
+    permission: raid.user
+    usage: "/raid <join|leave|status>"
+  stash:
+    description: View or manage extracted loot stored in your stash.
+    permission: raid.user
+    usage: "/stash"
+  raidadmin:
+    description: Administrative raid controls for testing and moderation.
+    permission: raid.admin
+    usage: "/raidadmin <start|stop|force-extract>"
+permissions:
+  raid.user:
+    description: Allows participation in raids and stash access.
+    default: true
+  raid.admin:
+    description: Allows administrative control over raids and extraction states.
+    default: op

--- a/src/main/resources/raids.yml
+++ b/src/main/resources/raids.yml
@@ -1,0 +1,21 @@
+# Raid definitions. Each raid references a loot table and optional evac zones.
+raids:
+  default_raid:
+    world: world
+    min_players: 1
+    max_players: 4
+    duration_seconds: 900
+    loot_table: starter_cache
+    evac_zones:
+      - name: Town Plaza
+        world: world
+        x: 100
+        y: 64
+        z: 100
+        radius: 6
+      - name: Forest Camp
+        world: world
+        x: -32
+        y: 68
+        z: 240
+        radius: 5


### PR DESCRIPTION
## Summary
- add default YAML configs for globals, raids, loot tables, and director pacing with inline comments
- implement ConfigManager and configuration models with soft validation for raids, evac zones, and loot tables
- wire the loader into the plugin lifecycle and document the completed configuration phase

## Testing
- not run (Gradle wrapper/distribution unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d24cfe1d883319235111081bac67a)