### PR TITLE
Add raid state machine skeleton

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This TODO tracks the cloud-safe implementation path for the Raid Extraction Pape
 - [x] Implement `ConfigManager` plus models (`RaidDefinition`, `EvacZoneDefinition`, `LootTableDefinition`, `LootEntry`) and soft validation.
 
 ## Phase 3 — Core Logic Skeleton
-- [ ] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.
+- [x] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.
 - [ ] Add `RaidManager` and `QueueManager` for routing and queue handling.
 
 ## Phase 4 — Persistence & Loot (Neutral Formats)

--- a/src/main/java/com/raidextraction/raid/RaidInstance.java
+++ b/src/main/java/com/raidextraction/raid/RaidInstance.java
@@ -1,0 +1,111 @@
+package com.raidextraction.raid;
+
+import com.raidextraction.config.model.RaidDefinition;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class RaidInstance {
+    private final String id;
+    private final RaidDefinition definition;
+    private final Clock clock;
+    private final Set<UUID> players;
+    private final Instant createdAt;
+    private RaidState state;
+    private Instant stateChangedAt;
+
+    public RaidInstance(String id, RaidDefinition definition, Clock clock) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.definition = Objects.requireNonNull(definition, "definition");
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.players = new LinkedHashSet<>();
+        this.createdAt = Instant.now(clock);
+        this.state = RaidState.LOBBY;
+        this.stateChangedAt = this.createdAt;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public RaidDefinition definition() {
+        return definition;
+    }
+
+    public RaidState state() {
+        return state;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant stateChangedAt() {
+        return stateChangedAt;
+    }
+
+    public Set<UUID> players() {
+        return Collections.unmodifiableSet(players);
+    }
+
+    public boolean addPlayer(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        if (state != RaidState.LOBBY && state != RaidState.DEPLOYING) {
+            return false;
+        }
+        if (players.size() >= definition.maxPlayers()) {
+            return false;
+        }
+        return players.add(playerId);
+    }
+
+    public boolean removePlayer(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        return players.remove(playerId);
+    }
+
+    public boolean isReadyToDeploy() {
+        int size = players.size();
+        return size >= definition.minPlayers() && size <= definition.maxPlayers();
+    }
+
+    public void markDeploying() {
+        transitionTo(RaidState.DEPLOYING);
+    }
+
+    public void markInRaid() {
+        transitionTo(RaidState.IN_RAID);
+    }
+
+    public void markExtracting() {
+        transitionTo(RaidState.EXTRACTING);
+    }
+
+    public void markEnded() {
+        transitionTo(RaidState.ENDED);
+    }
+
+    public Instant raidEndsAt() {
+        if (state != RaidState.IN_RAID) {
+            return null;
+        }
+        return stateChangedAt.plusSeconds(definition.durationSeconds());
+    }
+
+    public void transitionTo(RaidState nextState) {
+        Objects.requireNonNull(nextState, "nextState");
+        if (state == nextState) {
+            return;
+        }
+        if (!state.canTransitionTo(nextState)) {
+            throw new IllegalStateException("Invalid raid state transition: " + state + " -> " + nextState);
+        }
+        state = nextState;
+        stateChangedAt = Instant.now(clock);
+    }
+}

--- a/src/main/java/com/raidextraction/raid/RaidState.java
+++ b/src/main/java/com/raidextraction/raid/RaidState.java
@@ -1,0 +1,22 @@
+package com.raidextraction.raid;
+
+public enum RaidState {
+    LOBBY,
+    DEPLOYING,
+    IN_RAID,
+    EXTRACTING,
+    ENDED;
+
+    public boolean canTransitionTo(RaidState next) {
+        if (next == null) {
+            return false;
+        }
+        return switch (this) {
+            case LOBBY -> next == DEPLOYING || next == ENDED;
+            case DEPLOYING -> next == IN_RAID || next == ENDED;
+            case IN_RAID -> next == EXTRACTING || next == ENDED;
+            case EXTRACTING -> next == ENDED;
+            case ENDED -> false;
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Model the raid lifecycle (queue → deploy → raid → extract → end) with a small, testable state machine.
- Provide pure-logic components that can be exercised without a running Paper/Bukkit server.
- Progress the Phase 3 roadmap toward a core logic skeleton that other managers/services will consume.

### Description
- Add `RaidState` enum with explicit allowed transitions and a `canTransitionTo` guard method. 
- Add `RaidInstance` class that tracks `id`, `RaidDefinition`, clock-based timestamps, players, current state, and exposes state mutation helpers (`markDeploying`, `markInRaid`, `markExtracting`, `markEnded`, and `transitionTo`).
- Include player management (`addPlayer`, `removePlayer`), readiness checks (`isReadyToDeploy`), and timing helper (`raidEndsAt`) in `RaidInstance` with transition validation.
- Update `TODO.md` to mark the Phase 3 state machine milestone complete.

### Testing
- No automated tests were executed for this change in this environment. 
- The repository `./gradlew clean build` was not run due to the known Gradle wrapper download limitation in this environment (see `TODO.md`/`AGENTS.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9ad533848331b46d32573635cc7f)