### PR TITLE
Add raid and queue managers for routing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@ This TODO tracks the cloud-safe implementation path for the Raid Extraction Pape
 
 ## Phase 3 — Core Logic Skeleton
 - [x] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.
-- [ ] Add `RaidManager` and `QueueManager` for routing and queue handling.
+- [x] Add `RaidManager` and `QueueManager` for routing and queue handling.
 
 ## Phase 4 — Persistence & Loot (Neutral Formats)
 - [ ] Implement SQLite-backed `StashRepository` and `StashService` using neutral `ItemData` representation.

--- a/src/main/java/com/raidextraction/raid/QueueManager.java
+++ b/src/main/java/com/raidextraction/raid/QueueManager.java
@@ -1,0 +1,86 @@
+package com.raidextraction.raid;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class QueueManager {
+    private final Map<String, Deque<UUID>> queueByRaid = new HashMap<>();
+    private final Map<UUID, String> playerQueue = new HashMap<>();
+
+    public boolean enqueue(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        if (playerQueue.containsKey(playerId)) {
+            return false;
+        }
+        queueByRaid.computeIfAbsent(raidId, key -> new ArrayDeque<>()).addLast(playerId);
+        playerQueue.put(playerId, raidId);
+        return true;
+    }
+
+    public boolean remove(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        String raidId = playerQueue.remove(playerId);
+        if (raidId == null) {
+            return false;
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null) {
+            return false;
+        }
+        boolean removed = queue.remove(playerId);
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return removed;
+    }
+
+    public Optional<String> queuedRaid(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        return Optional.ofNullable(playerQueue.get(playerId));
+    }
+
+    public int size(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        return queue == null ? 0 : queue.size();
+    }
+
+    public List<UUID> snapshot(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(queue));
+    }
+
+    public List<UUID> drain(String raidId, int maxCount) {
+        Objects.requireNonNull(raidId, "raidId");
+        if (maxCount <= 0) {
+            return List.of();
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        List<UUID> drained = new ArrayList<>(Math.min(queue.size(), maxCount));
+        while (!queue.isEmpty() && drained.size() < maxCount) {
+            UUID playerId = queue.removeFirst();
+            drained.add(playerId);
+            playerQueue.remove(playerId);
+        }
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return drained;
+    }
+}

--- a/src/main/java/com/raidextraction/raid/RaidManager.java
+++ b/src/main/java/com/raidextraction/raid/RaidManager.java
@@ -1,0 +1,83 @@
+package com.raidextraction.raid;
+
+import com.raidextraction.config.model.RaidDefinition;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class RaidManager {
+    private final Map<String, RaidDefinition> definitions;
+    private final Map<String, RaidInstance> activeRaids = new HashMap<>();
+    private final QueueManager queueManager;
+    private final Clock clock;
+
+    public RaidManager(Map<String, RaidDefinition> definitions, QueueManager queueManager, Clock clock) {
+        this.definitions = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(definitions, "definitions")));
+        this.queueManager = Objects.requireNonNull(queueManager, "queueManager");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public Optional<RaidInstance> tryCreateFromQueue(String raidDefinitionId) {
+        Objects.requireNonNull(raidDefinitionId, "raidDefinitionId");
+        RaidDefinition definition = definitions.get(raidDefinitionId);
+        if (definition == null) {
+            return Optional.empty();
+        }
+        int queued = queueManager.size(raidDefinitionId);
+        if (queued < definition.minPlayers()) {
+            return Optional.empty();
+        }
+        int toDrain = Math.min(definition.maxPlayers(), queued);
+        List<UUID> players = queueManager.drain(raidDefinitionId, toDrain);
+        if (players.size() < definition.minPlayers()) {
+            for (UUID playerId : players) {
+                queueManager.enqueue(raidDefinitionId, playerId);
+            }
+            return Optional.empty();
+        }
+        return createRaid(definition, players);
+    }
+
+    public Optional<RaidInstance> createRaid(RaidDefinition definition, List<UUID> players) {
+        Objects.requireNonNull(definition, "definition");
+        Objects.requireNonNull(players, "players");
+        if (!definitions.containsKey(definition.id())) {
+            return Optional.empty();
+        }
+        List<UUID> uniquePlayers = new ArrayList<>(new java.util.LinkedHashSet<>(players));
+        int count = uniquePlayers.size();
+        if (count < definition.minPlayers() || count > definition.maxPlayers()) {
+            return Optional.empty();
+        }
+        String raidId = UUID.randomUUID().toString();
+        RaidInstance instance = new RaidInstance(raidId, definition, clock);
+        uniquePlayers.forEach(instance::addPlayer);
+        activeRaids.put(raidId, instance);
+        return Optional.of(instance);
+    }
+
+    public Optional<RaidInstance> getRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return Optional.ofNullable(activeRaids.get(raidId));
+    }
+
+    public List<RaidInstance> activeRaids() {
+        return List.copyOf(activeRaids.values());
+    }
+
+    public boolean endRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return activeRaids.remove(raidId) != null;
+    }
+
+    public Map<String, RaidDefinition> definitions() {
+        return definitions;
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement Phase 3 core logic to support queue → raid flow without server dependencies.
- Provide pure-logic routing so queued players can be grouped into raid instances for later integration.
- Enable future phases (loot, extraction, persistence, commands) to operate on in-memory raid objects.

### Description
- Add `QueueManager` with `enqueue`, `remove`, `queuedRaid`, `size`, `snapshot`, and `drain` methods to manage per-raid FIFO queues and player-to-queue mapping.
- Add `RaidManager` with `tryCreateFromQueue`, `createRaid`, `getRaid`, `activeRaids`, `endRaid`, and immutable `definitions` handling, using `QueueManager` and `Clock` for pure logic.
- Ensure `createRaid` deduplicates players and validates `minPlayers`/`maxPlayers` against `RaidDefinition` limits before creating a `RaidInstance`.
- Update `TODO.md` to mark the Phase 3 item for `RaidManager`/`QueueManager` as complete.

### Testing
- No automated tests were executed for this change.
- The repository `./gradlew clean build` was not run in this environment due to the Gradle wrapper distribution fetch being blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609e37e6448331a85c188cc8bcdfd7)