### PR TITLE
Add stash persistence and loot services

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,11 +22,11 @@ This TODO tracks the cloud-safe implementation path for the Raid Extraction Pape
 
 ## Phase 3 — Core Logic Skeleton
 - [x] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.
-- [ ] Add `RaidManager` and `QueueManager` for routing and queue handling.
+- [x] Add `RaidManager` and `QueueManager` for routing and queue handling.
 
 ## Phase 4 — Persistence & Loot (Neutral Formats)
-- [ ] Implement SQLite-backed `StashRepository` and `StashService` using neutral `ItemData` representation.
-- [ ] Implement `LootTableRegistry` and `LootService` with weighted rolls and injectable RNG seed.
+- [x] Implement SQLite-backed `StashRepository` and `StashService` using neutral `ItemData` representation.
+- [x] Implement `LootTableRegistry` and `LootService` with weighted rolls and injectable RNG seed.
 
 ## Phase 5 — Extraction Logic
 - [ ] Add `ExtractionService` and `EvacTracker` for countdown handling and idempotent completion.

--- a/src/main/java/com/raidextraction/loot/LootService.java
+++ b/src/main/java/com/raidextraction/loot/LootService.java
@@ -1,0 +1,59 @@
+package com.raidextraction.loot;
+
+import com.raidextraction.config.model.LootEntry;
+import com.raidextraction.config.model.LootTableDefinition;
+import com.raidextraction.stash.ItemData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+
+public final class LootService {
+    private final LootTableRegistry registry;
+    private final Random random;
+
+    public LootService(LootTableRegistry registry, Random random) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.random = Objects.requireNonNull(random, "random");
+    }
+
+    public List<ItemData> roll(String tableId, int rolls) {
+        if (rolls <= 0) {
+            return List.of();
+        }
+        Optional<LootTableDefinition> definition = registry.get(tableId);
+        if (definition.isEmpty()) {
+            return List.of();
+        }
+        LootTableDefinition table = definition.get();
+        if (!table.isValid()) {
+            return List.of();
+        }
+        List<LootEntry> entries = table.entries();
+        int totalWeight = entries.stream().mapToInt(LootEntry::weight).sum();
+        if (totalWeight <= 0) {
+            return List.of();
+        }
+        List<ItemData> results = new ArrayList<>(rolls);
+        for (int i = 0; i < rolls; i++) {
+            LootEntry entry = pickEntry(entries, totalWeight);
+            int amount = random.nextInt(entry.maxAmount() - entry.minAmount() + 1) + entry.minAmount();
+            results.add(new ItemData(entry.material(), amount));
+        }
+        return results;
+    }
+
+    private LootEntry pickEntry(List<LootEntry> entries, int totalWeight) {
+        int roll = random.nextInt(totalWeight);
+        int cursor = 0;
+        for (LootEntry entry : entries) {
+            cursor += entry.weight();
+            if (roll < cursor) {
+                return entry;
+            }
+        }
+        return entries.get(entries.size() - 1);
+    }
+}

--- a/src/main/java/com/raidextraction/loot/LootTableRegistry.java
+++ b/src/main/java/com/raidextraction/loot/LootTableRegistry.java
@@ -1,0 +1,33 @@
+package com.raidextraction.loot;
+
+import com.raidextraction.config.model.LootTableDefinition;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class LootTableRegistry {
+    private final Map<String, LootTableDefinition> tables = new HashMap<>();
+
+    public LootTableRegistry(Map<String, LootTableDefinition> definitions) {
+        if (definitions != null) {
+            tables.putAll(definitions);
+        }
+    }
+
+    public Optional<LootTableDefinition> get(String tableId) {
+        Objects.requireNonNull(tableId, "tableId");
+        return Optional.ofNullable(tables.get(tableId));
+    }
+
+    public void register(LootTableDefinition definition) {
+        Objects.requireNonNull(definition, "definition");
+        tables.put(definition.id(), definition);
+    }
+
+    public Map<String, LootTableDefinition> definitions() {
+        return Collections.unmodifiableMap(tables);
+    }
+}

--- a/src/main/java/com/raidextraction/raid/QueueManager.java
+++ b/src/main/java/com/raidextraction/raid/QueueManager.java
@@ -1,0 +1,86 @@
+package com.raidextraction.raid;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class QueueManager {
+    private final Map<String, Deque<UUID>> queueByRaid = new HashMap<>();
+    private final Map<UUID, String> playerQueue = new HashMap<>();
+
+    public boolean enqueue(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        if (playerQueue.containsKey(playerId)) {
+            return false;
+        }
+        queueByRaid.computeIfAbsent(raidId, key -> new ArrayDeque<>()).addLast(playerId);
+        playerQueue.put(playerId, raidId);
+        return true;
+    }
+
+    public boolean remove(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        String raidId = playerQueue.remove(playerId);
+        if (raidId == null) {
+            return false;
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null) {
+            return false;
+        }
+        boolean removed = queue.remove(playerId);
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return removed;
+    }
+
+    public Optional<String> queuedRaid(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        return Optional.ofNullable(playerQueue.get(playerId));
+    }
+
+    public int size(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        return queue == null ? 0 : queue.size();
+    }
+
+    public List<UUID> snapshot(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(queue));
+    }
+
+    public List<UUID> drain(String raidId, int maxCount) {
+        Objects.requireNonNull(raidId, "raidId");
+        if (maxCount <= 0) {
+            return List.of();
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        List<UUID> drained = new ArrayList<>(Math.min(queue.size(), maxCount));
+        while (!queue.isEmpty() && drained.size() < maxCount) {
+            UUID playerId = queue.removeFirst();
+            drained.add(playerId);
+            playerQueue.remove(playerId);
+        }
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return drained;
+    }
+}

--- a/src/main/java/com/raidextraction/raid/RaidManager.java
+++ b/src/main/java/com/raidextraction/raid/RaidManager.java
@@ -1,0 +1,83 @@
+package com.raidextraction.raid;
+
+import com.raidextraction.config.model.RaidDefinition;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class RaidManager {
+    private final Map<String, RaidDefinition> definitions;
+    private final Map<String, RaidInstance> activeRaids = new HashMap<>();
+    private final QueueManager queueManager;
+    private final Clock clock;
+
+    public RaidManager(Map<String, RaidDefinition> definitions, QueueManager queueManager, Clock clock) {
+        this.definitions = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(definitions, "definitions")));
+        this.queueManager = Objects.requireNonNull(queueManager, "queueManager");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public Optional<RaidInstance> tryCreateFromQueue(String raidDefinitionId) {
+        Objects.requireNonNull(raidDefinitionId, "raidDefinitionId");
+        RaidDefinition definition = definitions.get(raidDefinitionId);
+        if (definition == null) {
+            return Optional.empty();
+        }
+        int queued = queueManager.size(raidDefinitionId);
+        if (queued < definition.minPlayers()) {
+            return Optional.empty();
+        }
+        int toDrain = Math.min(definition.maxPlayers(), queued);
+        List<UUID> players = queueManager.drain(raidDefinitionId, toDrain);
+        if (players.size() < definition.minPlayers()) {
+            for (UUID playerId : players) {
+                queueManager.enqueue(raidDefinitionId, playerId);
+            }
+            return Optional.empty();
+        }
+        return createRaid(definition, players);
+    }
+
+    public Optional<RaidInstance> createRaid(RaidDefinition definition, List<UUID> players) {
+        Objects.requireNonNull(definition, "definition");
+        Objects.requireNonNull(players, "players");
+        if (!definitions.containsKey(definition.id())) {
+            return Optional.empty();
+        }
+        List<UUID> uniquePlayers = new ArrayList<>(new java.util.LinkedHashSet<>(players));
+        int count = uniquePlayers.size();
+        if (count < definition.minPlayers() || count > definition.maxPlayers()) {
+            return Optional.empty();
+        }
+        String raidId = UUID.randomUUID().toString();
+        RaidInstance instance = new RaidInstance(raidId, definition, clock);
+        uniquePlayers.forEach(instance::addPlayer);
+        activeRaids.put(raidId, instance);
+        return Optional.of(instance);
+    }
+
+    public Optional<RaidInstance> getRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return Optional.ofNullable(activeRaids.get(raidId));
+    }
+
+    public List<RaidInstance> activeRaids() {
+        return List.copyOf(activeRaids.values());
+    }
+
+    public boolean endRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return activeRaids.remove(raidId) != null;
+    }
+
+    public Map<String, RaidDefinition> definitions() {
+        return definitions;
+    }
+}

--- a/src/main/java/com/raidextraction/stash/ItemData.java
+++ b/src/main/java/com/raidextraction/stash/ItemData.java
@@ -1,0 +1,26 @@
+package com.raidextraction.stash;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public record ItemData(String material, int amount, Map<String, String> tags) {
+    public ItemData {
+        Objects.requireNonNull(material, "material");
+        if (material.isBlank()) {
+            throw new IllegalArgumentException("material cannot be blank");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        if (tags == null) {
+            tags = Map.of();
+        }
+        tags = Collections.unmodifiableMap(new HashMap<>(tags));
+    }
+
+    public ItemData(String material, int amount) {
+        this(material, amount, Map.of());
+    }
+}

--- a/src/main/java/com/raidextraction/stash/SQLiteStashRepository.java
+++ b/src/main/java/com/raidextraction/stash/SQLiteStashRepository.java
@@ -1,0 +1,196 @@
+package com.raidextraction.stash;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public final class SQLiteStashRepository implements StashRepository {
+    private final String jdbcUrl;
+
+    public SQLiteStashRepository(Path databasePath) {
+        Objects.requireNonNull(databasePath, "databasePath");
+        this.jdbcUrl = "jdbc:sqlite:" + databasePath.toAbsolutePath();
+        ensureSchema();
+    }
+
+    @Override
+    public List<ItemData> loadStash(UUID ownerId) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        String sql = "SELECT slot, material, amount, tags FROM stash_items WHERE owner_uuid = ? ORDER BY slot ASC";
+        List<ItemData> items = new ArrayList<>();
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, ownerId.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String material = resultSet.getString("material");
+                    int amount = resultSet.getInt("amount");
+                    String tagsValue = resultSet.getString("tags");
+                    items.add(new ItemData(material, amount, deserializeTags(tagsValue)));
+                }
+            }
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to load stash for " + ownerId, error);
+        }
+        return Collections.unmodifiableList(items);
+    }
+
+    @Override
+    public void saveStash(UUID ownerId, List<ItemData> items) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        Objects.requireNonNull(items, "items");
+        String deleteSql = "DELETE FROM stash_items WHERE owner_uuid = ?";
+        String insertSql = "INSERT INTO stash_items (owner_uuid, slot, material, amount, tags) VALUES (?, ?, ?, ?, ?)";
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement deleteStatement = connection.prepareStatement(deleteSql)) {
+                deleteStatement.setString(1, ownerId.toString());
+                deleteStatement.executeUpdate();
+            }
+            try (PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
+                int slot = 0;
+                for (ItemData item : items) {
+                    insertStatement.setString(1, ownerId.toString());
+                    insertStatement.setInt(2, slot++);
+                    insertStatement.setString(3, item.material());
+                    insertStatement.setInt(4, item.amount());
+                    insertStatement.setString(5, serializeTags(item.tags()));
+                    insertStatement.addBatch();
+                }
+                insertStatement.executeBatch();
+            }
+            connection.commit();
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to save stash for " + ownerId, error);
+        }
+    }
+
+    @Override
+    public void clearStash(UUID ownerId) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        String deleteSql = "DELETE FROM stash_items WHERE owner_uuid = ?";
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(deleteSql)) {
+            statement.setString(1, ownerId.toString());
+            statement.executeUpdate();
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to clear stash for " + ownerId, error);
+        }
+    }
+
+    private void ensureSchema() {
+        String sql = """
+                CREATE TABLE IF NOT EXISTS stash_items (
+                    owner_uuid TEXT NOT NULL,
+                    slot INTEGER NOT NULL,
+                    material TEXT NOT NULL,
+                    amount INTEGER NOT NULL,
+                    tags TEXT,
+                    PRIMARY KEY (owner_uuid, slot)
+                )
+                """;
+        try (Connection connection = openConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to ensure stash schema", error);
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    private String serializeTags(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return "";
+        }
+        return tags.entrySet().stream()
+                .map(entry -> escape(entry.getKey()) + "=" + escape(entry.getValue()))
+                .collect(Collectors.joining(";"));
+    }
+
+    private Map<String, String> deserializeTags(String value) {
+        if (value == null || value.isBlank()) {
+            return Map.of();
+        }
+        Map<String, String> tags = new HashMap<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (escaping) {
+                current.append(character);
+                escaping = false;
+                continue;
+            }
+            if (character == '\\') {
+                escaping = true;
+                continue;
+            }
+            if (character == ';') {
+                addTagPair(tags, current.toString());
+                current.setLength(0);
+            } else {
+                current.append(character);
+            }
+        }
+        if (escaping) {
+            current.append('\\');
+        }
+        addTagPair(tags, current.toString());
+        return tags;
+    }
+
+    private void addTagPair(Map<String, String> tags, String rawPair) {
+        if (rawPair == null || rawPair.isEmpty()) {
+            return;
+        }
+        int index = rawPair.indexOf('=');
+        if (index < 0) {
+            tags.put(unescape(rawPair), "");
+            return;
+        }
+        String key = unescape(rawPair.substring(0, index));
+        String val = unescape(rawPair.substring(index + 1));
+        tags.put(key, val);
+    }
+
+    private String escape(String value) {
+        return value.replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace("=", "\\=");
+    }
+
+    private String unescape(String value) {
+        StringBuilder builder = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (escaping) {
+                builder.append(character);
+                escaping = false;
+            } else if (character == '\\') {
+                escaping = true;
+            } else {
+                builder.append(character);
+            }
+        }
+        if (escaping) {
+            builder.append('\\');
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/raidextraction/stash/StashRepository.java
+++ b/src/main/java/com/raidextraction/stash/StashRepository.java
@@ -1,0 +1,12 @@
+package com.raidextraction.stash;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StashRepository {
+    List<ItemData> loadStash(UUID ownerId);
+
+    void saveStash(UUID ownerId, List<ItemData> items);
+
+    void clearStash(UUID ownerId);
+}

--- a/src/main/java/com/raidextraction/stash/StashService.java
+++ b/src/main/java/com/raidextraction/stash/StashService.java
@@ -1,0 +1,43 @@
+package com.raidextraction.stash;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class StashService {
+    private final StashRepository repository;
+
+    public StashService(StashRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+    }
+
+    public List<ItemData> load(UUID ownerId) {
+        return repository.loadStash(ownerId);
+    }
+
+    public void replace(UUID ownerId, List<ItemData> items) {
+        repository.saveStash(ownerId, items);
+    }
+
+    public void clear(UUID ownerId) {
+        repository.clearStash(ownerId);
+    }
+
+    public void addItem(UUID ownerId, ItemData itemData) {
+        Objects.requireNonNull(itemData, "itemData");
+        List<ItemData> items = new ArrayList<>(repository.loadStash(ownerId));
+        items.add(itemData);
+        repository.saveStash(ownerId, items);
+    }
+
+    public boolean removeItem(UUID ownerId, ItemData itemData) {
+        Objects.requireNonNull(itemData, "itemData");
+        List<ItemData> items = new ArrayList<>(repository.loadStash(ownerId));
+        boolean removed = items.remove(itemData);
+        if (removed) {
+            repository.saveStash(ownerId, items);
+        }
+        return removed;
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement Phase 4 to persist player stashes in a neutral format and provide loot generation to support the raid → loot → stash flow.
- Provide a neutral item model so stash persistence does not depend on Minecraft runtime types by adding `ItemData`.
- Add a SQLite-backed `StashRepository` and service layer to store and mutate stashes reliably on disk.
- Provide a registry and RNG-injectable `LootService` to produce weighted loot rolls as `ItemData`.

### Description
- Add `ItemData` record with input validation and immutable `tags` map to represent items independent of the game server.
- Add `StashRepository` interface and `SQLiteStashRepository` implementation that ensures schema, performs transactional `saveStash`, and implements robust `serialize`/`deserialize` escaping for `tags`.
- Add `StashService` with `load`, `replace`, `clear`, `addItem`, and `removeItem` helpers that delegate to the repository.
- Add `LootTableRegistry` and `LootService` that perform weighted entry selection and quantity rolls using an injected `Random` and return lists of `ItemData`.

### Testing
- No automated tests were executed for this change.
- The Gradle build was not run in this environment due to wrapper/distribution fetch constraints using `./gradlew clean build`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609e37e6448331a85c188cc8bcdfd7)