### PR TITLE
Add command and listener stubs and wire core services (raid/queue/loot/extraction/stash)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,17 +22,17 @@ This TODO tracks the cloud-safe implementation path for the Raid Extraction Pape
 
 ## Phase 3 — Core Logic Skeleton
 - [x] Define `RaidState` enum and `RaidInstance` state machine (deploy → raid → extract → end) with pure logic only.
-- [ ] Add `RaidManager` and `QueueManager` for routing and queue handling.
+- [x] Add `RaidManager` and `QueueManager` for routing and queue handling.
 
 ## Phase 4 — Persistence & Loot (Neutral Formats)
-- [ ] Implement SQLite-backed `StashRepository` and `StashService` using neutral `ItemData` representation.
-- [ ] Implement `LootTableRegistry` and `LootService` with weighted rolls and injectable RNG seed.
+- [x] Implement SQLite-backed `StashRepository` and `StashService` using neutral `ItemData` representation.
+- [x] Implement `LootTableRegistry` and `LootService` with weighted rolls and injectable RNG seed.
 
 ## Phase 5 — Extraction Logic
-- [ ] Add `ExtractionService` and `EvacTracker` for countdown handling and idempotent completion.
+- [x] Add `ExtractionService` and `EvacTracker` for countdown handling and idempotent completion.
 
 ## Phase 6 — Commands & Listeners (Stubs)
-- [ ] Provide skeleton commands (`RaidCommand`, `StashCommand`, admin) and listener stubs that delegate to managers.
+- [x] Provide skeleton commands (`RaidCommand`, `StashCommand`, admin) and listener stubs that delegate to managers.
 
 ## Phase 7 — Documentation & Integration Checklist
 - [ ] Expand README with local Paper testing steps, integration hooks (teleport, inventory snapshot, region checks, GUI stash, chest filling), and cloud/local notes.

--- a/src/main/java/com/raidextraction/RaidExtractionPlugin.java
+++ b/src/main/java/com/raidextraction/RaidExtractionPlugin.java
@@ -1,7 +1,23 @@
 package com.raidextraction;
 
 import com.raidextraction.config.ConfigManager;
+import com.raidextraction.command.RaidAdminCommand;
+import com.raidextraction.command.RaidCommand;
+import com.raidextraction.command.StashCommand;
+import com.raidextraction.extraction.EvacTracker;
+import com.raidextraction.extraction.ExtractionService;
+import com.raidextraction.loot.LootService;
+import com.raidextraction.loot.LootTableRegistry;
+import com.raidextraction.raid.QueueManager;
+import com.raidextraction.raid.RaidManager;
+import com.raidextraction.stash.SQLiteStashRepository;
+import com.raidextraction.stash.StashService;
+import com.raidextraction.listener.ExtractionListener;
+import com.raidextraction.listener.RaidListener;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.time.Clock;
+import java.util.Random;
 
 /**
  * Base plugin entrypoint for the Raid Extraction Paper plugin.
@@ -9,6 +25,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class RaidExtractionPlugin extends JavaPlugin {
 
     private ConfigManager configManager;
+    private QueueManager queueManager;
+    private RaidManager raidManager;
+    private LootTableRegistry lootTableRegistry;
+    private LootService lootService;
+    private StashService stashService;
+    private ExtractionService extractionService;
 
     @Override
     public void onLoad() {
@@ -21,6 +43,9 @@ public final class RaidExtractionPlugin extends JavaPlugin {
         getLogger().info("RaidExtraction plugin enabling (commands and listeners will register in later phases).");
         prepareDataFolder();
         initializeConfigurationScaffolding();
+        initializeServices();
+        registerCommands();
+        registerListeners();
     }
 
     @Override
@@ -30,6 +55,26 @@ public final class RaidExtractionPlugin extends JavaPlugin {
 
     public ConfigManager getConfigManager() {
         return configManager;
+    }
+
+    public RaidManager getRaidManager() {
+        return raidManager;
+    }
+
+    public QueueManager getQueueManager() {
+        return queueManager;
+    }
+
+    public LootService getLootService() {
+        return lootService;
+    }
+
+    public StashService getStashService() {
+        return stashService;
+    }
+
+    public ExtractionService getExtractionService() {
+        return extractionService;
     }
 
     private void prepareDataFolder() {
@@ -51,5 +96,32 @@ public final class RaidExtractionPlugin extends JavaPlugin {
         }
 
         getLogger().info("Configuration scaffolding ready; raid and loot definitions loaded for future phases.");
+    }
+
+    private void initializeServices() {
+        Clock clock = Clock.systemUTC();
+        queueManager = new QueueManager();
+        raidManager = new RaidManager(configManager.getRaidDefinitions(), queueManager, clock);
+        lootTableRegistry = new LootTableRegistry(configManager.getLootTableDefinitions());
+        lootService = new LootService(lootTableRegistry, new Random());
+        stashService = new StashService(new SQLiteStashRepository(getDataFolder().toPath().resolve("stash.db")));
+        extractionService = new ExtractionService(new EvacTracker(clock));
+    }
+
+    private void registerCommands() {
+        if (getCommand("raid") != null) {
+            getCommand("raid").setExecutor(new RaidCommand(raidManager, queueManager));
+        }
+        if (getCommand("stash") != null) {
+            getCommand("stash").setExecutor(new StashCommand(stashService));
+        }
+        if (getCommand("raidadmin") != null) {
+            getCommand("raidadmin").setExecutor(new RaidAdminCommand(raidManager, extractionService));
+        }
+    }
+
+    private void registerListeners() {
+        getServer().getPluginManager().registerEvents(new RaidListener(raidManager), this);
+        getServer().getPluginManager().registerEvents(new ExtractionListener(extractionService), this);
     }
 }

--- a/src/main/java/com/raidextraction/command/RaidAdminCommand.java
+++ b/src/main/java/com/raidextraction/command/RaidAdminCommand.java
@@ -1,0 +1,77 @@
+package com.raidextraction.command;
+
+import com.raidextraction.extraction.ExtractionService;
+import com.raidextraction.raid.RaidManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Objects;
+
+public final class RaidAdminCommand implements CommandExecutor {
+    private final RaidManager raidManager;
+    private final ExtractionService extractionService;
+
+    public RaidAdminCommand(RaidManager raidManager, ExtractionService extractionService) {
+        this.raidManager = Objects.requireNonNull(raidManager, "raidManager");
+        this.extractionService = Objects.requireNonNull(extractionService, "extractionService");
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /raidadmin <start|stop|force-extract> [raidId]");
+            return true;
+        }
+        String action = args[0].toLowerCase();
+        return switch (action) {
+            case "start" -> handleStart(sender, args);
+            case "stop" -> handleStop(sender, args);
+            case "force-extract" -> handleForceExtract(sender, args);
+            default -> {
+                sender.sendMessage("Unknown subcommand. Use /raidadmin <start|stop|force-extract>.");
+                yield true;
+            }
+        };
+    }
+
+    private boolean handleStart(CommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /raidadmin start <raidId>");
+            return true;
+        }
+        String raidId = args[1];
+        if (!raidManager.definitions().containsKey(raidId)) {
+            sender.sendMessage("Unknown raid id: " + raidId);
+            return true;
+        }
+        boolean created = raidManager.tryCreateFromQueue(raidId).isPresent();
+        sender.sendMessage(created
+                ? "Raid created from queue for " + raidId + "."
+                : "Not enough players queued for " + raidId + ".");
+        return true;
+    }
+
+    private boolean handleStop(CommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /raidadmin stop <activeRaidId>");
+            return true;
+        }
+        String raidId = args[1];
+        boolean removed = raidManager.endRaid(raidId);
+        if (removed) {
+            extractionService.clearRaid(raidId);
+        }
+        sender.sendMessage(removed ? "Ended raid " + raidId + "." : "No active raid with id " + raidId + ".");
+        return true;
+    }
+
+    private boolean handleForceExtract(CommandSender sender, String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage("Usage: /raidadmin force-extract <activeRaidId> <playerUuid>");
+            return true;
+        }
+        sender.sendMessage("Force extract is a stub; integrate with player lookups and stash handling.");
+        return true;
+    }
+}

--- a/src/main/java/com/raidextraction/command/RaidCommand.java
+++ b/src/main/java/com/raidextraction/command/RaidCommand.java
@@ -1,0 +1,78 @@
+package com.raidextraction.command;
+
+import com.raidextraction.raid.QueueManager;
+import com.raidextraction.raid.RaidManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class RaidCommand implements CommandExecutor {
+    private final RaidManager raidManager;
+    private final QueueManager queueManager;
+
+    public RaidCommand(RaidManager raidManager, QueueManager queueManager) {
+        this.raidManager = Objects.requireNonNull(raidManager, "raidManager");
+        this.queueManager = Objects.requireNonNull(queueManager, "queueManager");
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /raid <join|leave|status> [raidId]");
+            return true;
+        }
+        String action = args[0].toLowerCase();
+        UUID playerId = player.getUniqueId();
+        return switch (action) {
+            case "join" -> handleJoin(sender, playerId, args);
+            case "leave" -> handleLeave(sender, playerId);
+            case "status" -> handleStatus(sender, playerId);
+            default -> {
+                sender.sendMessage("Unknown subcommand. Use /raid <join|leave|status>.");
+                yield true;
+            }
+        };
+    }
+
+    private boolean handleJoin(CommandSender sender, UUID playerId, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /raid join <raidId>");
+            return true;
+        }
+        String raidId = args[1];
+        if (!raidManager.definitions().containsKey(raidId)) {
+            sender.sendMessage("Unknown raid id: " + raidId);
+            return true;
+        }
+        boolean queued = queueManager.enqueue(raidId, playerId);
+        sender.sendMessage(queued
+                ? "Queued for raid " + raidId + "."
+                : "You are already queued for a raid.");
+        return true;
+    }
+
+    private boolean handleLeave(CommandSender sender, UUID playerId) {
+        boolean removed = queueManager.remove(playerId);
+        sender.sendMessage(removed ? "You have left the raid queue." : "You are not in a raid queue.");
+        return true;
+    }
+
+    private boolean handleStatus(CommandSender sender, UUID playerId) {
+        Optional<String> queuedRaid = queueManager.queuedRaid(playerId);
+        if (queuedRaid.isEmpty()) {
+            sender.sendMessage("You are not queued for any raid.");
+            return true;
+        }
+        sender.sendMessage("Queued for raid " + queuedRaid.get() + ".");
+        return true;
+    }
+}

--- a/src/main/java/com/raidextraction/command/StashCommand.java
+++ b/src/main/java/com/raidextraction/command/StashCommand.java
@@ -1,0 +1,32 @@
+package com.raidextraction.command;
+
+import com.raidextraction.stash.ItemData;
+import com.raidextraction.stash.StashService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class StashCommand implements CommandExecutor {
+    private final StashService stashService;
+
+    public StashCommand(StashService stashService) {
+        this.stashService = Objects.requireNonNull(stashService, "stashService");
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        UUID ownerId = player.getUniqueId();
+        List<ItemData> items = stashService.load(ownerId);
+        sender.sendMessage("Your stash contains " + items.size() + " item stack(s).");
+        return true;
+    }
+}

--- a/src/main/java/com/raidextraction/extraction/EvacTracker.java
+++ b/src/main/java/com/raidextraction/extraction/EvacTracker.java
@@ -1,0 +1,83 @@
+package com.raidextraction.extraction;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class EvacTracker {
+    private final Clock clock;
+    private final Map<EvacKey, EvacEntry> activeEntries = new HashMap<>();
+
+    public EvacTracker(Clock clock) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public boolean startCountdown(String raidId, UUID playerId, String zoneName, Duration duration) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(zoneName, "zoneName");
+        Objects.requireNonNull(duration, "duration");
+        if (duration.isZero() || duration.isNegative()) {
+            return false;
+        }
+        EvacKey key = new EvacKey(raidId, playerId);
+        if (activeEntries.containsKey(key)) {
+            return false;
+        }
+        activeEntries.put(key, new EvacEntry(zoneName, Instant.now(clock), duration));
+        return true;
+    }
+
+    public void cancelCountdown(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        activeEntries.remove(new EvacKey(raidId, playerId));
+    }
+
+    public Optional<EvacEntry> entry(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        return Optional.ofNullable(activeEntries.get(new EvacKey(raidId, playerId)));
+    }
+
+    public boolean isComplete(String raidId, UUID playerId) {
+        return entry(raidId, playerId).map(entry -> !entry.remaining(clock).isPositive()).orElse(false);
+    }
+
+    public Duration remaining(String raidId, UUID playerId) {
+        return entry(raidId, playerId)
+                .map(entry -> entry.remaining(clock))
+                .orElse(Duration.ZERO);
+    }
+
+    public void clearRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        activeEntries.keySet().removeIf(key -> key.raidId.equals(raidId));
+    }
+
+    public record EvacEntry(String zoneName, Instant startedAt, Duration duration) {
+        public EvacEntry {
+            Objects.requireNonNull(zoneName, "zoneName");
+            Objects.requireNonNull(startedAt, "startedAt");
+            Objects.requireNonNull(duration, "duration");
+        }
+
+        public Duration remaining(Clock clock) {
+            Duration elapsed = Duration.between(startedAt, Instant.now(clock));
+            Duration remaining = duration.minus(elapsed);
+            return remaining.isNegative() ? Duration.ZERO : remaining;
+        }
+    }
+
+    private record EvacKey(String raidId, UUID playerId) {
+        private EvacKey {
+            Objects.requireNonNull(raidId, "raidId");
+            Objects.requireNonNull(playerId, "playerId");
+        }
+    }
+}

--- a/src/main/java/com/raidextraction/extraction/ExtractionService.java
+++ b/src/main/java/com/raidextraction/extraction/ExtractionService.java
@@ -1,0 +1,81 @@
+package com.raidextraction.extraction;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class ExtractionService {
+    private final EvacTracker evacTracker;
+    private final Map<String, Set<UUID>> extractedPlayers = new HashMap<>();
+
+    public ExtractionService(EvacTracker evacTracker) {
+        this.evacTracker = Objects.requireNonNull(evacTracker, "evacTracker");
+    }
+
+    public ExtractionResult beginExtraction(String raidId, UUID playerId, String zoneName, Duration duration) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(zoneName, "zoneName");
+        Objects.requireNonNull(duration, "duration");
+        if (isExtracted(raidId, playerId)) {
+            return ExtractionResult.ALREADY_EXTRACTED;
+        }
+        boolean started = evacTracker.startCountdown(raidId, playerId, zoneName, duration);
+        return started ? ExtractionResult.STARTED : ExtractionResult.ALREADY_TRACKING;
+    }
+
+    public ExtractionResult completeIfReady(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        if (isExtracted(raidId, playerId)) {
+            return ExtractionResult.ALREADY_EXTRACTED;
+        }
+        if (!evacTracker.isComplete(raidId, playerId)) {
+            return ExtractionResult.NOT_READY;
+        }
+        evacTracker.cancelCountdown(raidId, playerId);
+        extractedPlayers.computeIfAbsent(raidId, key -> new HashSet<>()).add(playerId);
+        return ExtractionResult.EXTRACTED;
+    }
+
+    public void cancelExtraction(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        evacTracker.cancelCountdown(raidId, playerId);
+    }
+
+    public boolean isExtracted(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        Set<UUID> extracted = extractedPlayers.get(raidId);
+        return extracted != null && extracted.contains(playerId);
+    }
+
+    public Set<UUID> extractedPlayers(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Set<UUID> extracted = extractedPlayers.get(raidId);
+        if (extracted == null || extracted.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(extracted);
+    }
+
+    public void clearRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        evacTracker.clearRaid(raidId);
+        extractedPlayers.remove(raidId);
+    }
+
+    public enum ExtractionResult {
+        STARTED,
+        ALREADY_TRACKING,
+        NOT_READY,
+        EXTRACTED,
+        ALREADY_EXTRACTED
+    }
+}

--- a/src/main/java/com/raidextraction/listener/ExtractionListener.java
+++ b/src/main/java/com/raidextraction/listener/ExtractionListener.java
@@ -1,0 +1,14 @@
+package com.raidextraction.listener;
+
+import com.raidextraction.extraction.ExtractionService;
+import org.bukkit.event.Listener;
+
+import java.util.Objects;
+
+public final class ExtractionListener implements Listener {
+    private final ExtractionService extractionService;
+
+    public ExtractionListener(ExtractionService extractionService) {
+        this.extractionService = Objects.requireNonNull(extractionService, "extractionService");
+    }
+}

--- a/src/main/java/com/raidextraction/listener/RaidListener.java
+++ b/src/main/java/com/raidextraction/listener/RaidListener.java
@@ -1,0 +1,14 @@
+package com.raidextraction.listener;
+
+import com.raidextraction.raid.RaidManager;
+import org.bukkit.event.Listener;
+
+import java.util.Objects;
+
+public final class RaidListener implements Listener {
+    private final RaidManager raidManager;
+
+    public RaidListener(RaidManager raidManager) {
+        this.raidManager = Objects.requireNonNull(raidManager, "raidManager");
+    }
+}

--- a/src/main/java/com/raidextraction/loot/LootService.java
+++ b/src/main/java/com/raidextraction/loot/LootService.java
@@ -1,0 +1,59 @@
+package com.raidextraction.loot;
+
+import com.raidextraction.config.model.LootEntry;
+import com.raidextraction.config.model.LootTableDefinition;
+import com.raidextraction.stash.ItemData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+
+public final class LootService {
+    private final LootTableRegistry registry;
+    private final Random random;
+
+    public LootService(LootTableRegistry registry, Random random) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.random = Objects.requireNonNull(random, "random");
+    }
+
+    public List<ItemData> roll(String tableId, int rolls) {
+        if (rolls <= 0) {
+            return List.of();
+        }
+        Optional<LootTableDefinition> definition = registry.get(tableId);
+        if (definition.isEmpty()) {
+            return List.of();
+        }
+        LootTableDefinition table = definition.get();
+        if (!table.isValid()) {
+            return List.of();
+        }
+        List<LootEntry> entries = table.entries();
+        int totalWeight = entries.stream().mapToInt(LootEntry::weight).sum();
+        if (totalWeight <= 0) {
+            return List.of();
+        }
+        List<ItemData> results = new ArrayList<>(rolls);
+        for (int i = 0; i < rolls; i++) {
+            LootEntry entry = pickEntry(entries, totalWeight);
+            int amount = random.nextInt(entry.maxAmount() - entry.minAmount() + 1) + entry.minAmount();
+            results.add(new ItemData(entry.material(), amount));
+        }
+        return results;
+    }
+
+    private LootEntry pickEntry(List<LootEntry> entries, int totalWeight) {
+        int roll = random.nextInt(totalWeight);
+        int cursor = 0;
+        for (LootEntry entry : entries) {
+            cursor += entry.weight();
+            if (roll < cursor) {
+                return entry;
+            }
+        }
+        return entries.get(entries.size() - 1);
+    }
+}

--- a/src/main/java/com/raidextraction/loot/LootTableRegistry.java
+++ b/src/main/java/com/raidextraction/loot/LootTableRegistry.java
@@ -1,0 +1,33 @@
+package com.raidextraction.loot;
+
+import com.raidextraction.config.model.LootTableDefinition;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class LootTableRegistry {
+    private final Map<String, LootTableDefinition> tables = new HashMap<>();
+
+    public LootTableRegistry(Map<String, LootTableDefinition> definitions) {
+        if (definitions != null) {
+            tables.putAll(definitions);
+        }
+    }
+
+    public Optional<LootTableDefinition> get(String tableId) {
+        Objects.requireNonNull(tableId, "tableId");
+        return Optional.ofNullable(tables.get(tableId));
+    }
+
+    public void register(LootTableDefinition definition) {
+        Objects.requireNonNull(definition, "definition");
+        tables.put(definition.id(), definition);
+    }
+
+    public Map<String, LootTableDefinition> definitions() {
+        return Collections.unmodifiableMap(tables);
+    }
+}

--- a/src/main/java/com/raidextraction/raid/QueueManager.java
+++ b/src/main/java/com/raidextraction/raid/QueueManager.java
@@ -1,0 +1,86 @@
+package com.raidextraction.raid;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class QueueManager {
+    private final Map<String, Deque<UUID>> queueByRaid = new HashMap<>();
+    private final Map<UUID, String> playerQueue = new HashMap<>();
+
+    public boolean enqueue(String raidId, UUID playerId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Objects.requireNonNull(playerId, "playerId");
+        if (playerQueue.containsKey(playerId)) {
+            return false;
+        }
+        queueByRaid.computeIfAbsent(raidId, key -> new ArrayDeque<>()).addLast(playerId);
+        playerQueue.put(playerId, raidId);
+        return true;
+    }
+
+    public boolean remove(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        String raidId = playerQueue.remove(playerId);
+        if (raidId == null) {
+            return false;
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null) {
+            return false;
+        }
+        boolean removed = queue.remove(playerId);
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return removed;
+    }
+
+    public Optional<String> queuedRaid(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        return Optional.ofNullable(playerQueue.get(playerId));
+    }
+
+    public int size(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        return queue == null ? 0 : queue.size();
+    }
+
+    public List<UUID> snapshot(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(queue));
+    }
+
+    public List<UUID> drain(String raidId, int maxCount) {
+        Objects.requireNonNull(raidId, "raidId");
+        if (maxCount <= 0) {
+            return List.of();
+        }
+        Deque<UUID> queue = queueByRaid.get(raidId);
+        if (queue == null || queue.isEmpty()) {
+            return List.of();
+        }
+        List<UUID> drained = new ArrayList<>(Math.min(queue.size(), maxCount));
+        while (!queue.isEmpty() && drained.size() < maxCount) {
+            UUID playerId = queue.removeFirst();
+            drained.add(playerId);
+            playerQueue.remove(playerId);
+        }
+        if (queue.isEmpty()) {
+            queueByRaid.remove(raidId);
+        }
+        return drained;
+    }
+}

--- a/src/main/java/com/raidextraction/raid/RaidManager.java
+++ b/src/main/java/com/raidextraction/raid/RaidManager.java
@@ -1,0 +1,83 @@
+package com.raidextraction.raid;
+
+import com.raidextraction.config.model.RaidDefinition;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class RaidManager {
+    private final Map<String, RaidDefinition> definitions;
+    private final Map<String, RaidInstance> activeRaids = new HashMap<>();
+    private final QueueManager queueManager;
+    private final Clock clock;
+
+    public RaidManager(Map<String, RaidDefinition> definitions, QueueManager queueManager, Clock clock) {
+        this.definitions = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(definitions, "definitions")));
+        this.queueManager = Objects.requireNonNull(queueManager, "queueManager");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public Optional<RaidInstance> tryCreateFromQueue(String raidDefinitionId) {
+        Objects.requireNonNull(raidDefinitionId, "raidDefinitionId");
+        RaidDefinition definition = definitions.get(raidDefinitionId);
+        if (definition == null) {
+            return Optional.empty();
+        }
+        int queued = queueManager.size(raidDefinitionId);
+        if (queued < definition.minPlayers()) {
+            return Optional.empty();
+        }
+        int toDrain = Math.min(definition.maxPlayers(), queued);
+        List<UUID> players = queueManager.drain(raidDefinitionId, toDrain);
+        if (players.size() < definition.minPlayers()) {
+            for (UUID playerId : players) {
+                queueManager.enqueue(raidDefinitionId, playerId);
+            }
+            return Optional.empty();
+        }
+        return createRaid(definition, players);
+    }
+
+    public Optional<RaidInstance> createRaid(RaidDefinition definition, List<UUID> players) {
+        Objects.requireNonNull(definition, "definition");
+        Objects.requireNonNull(players, "players");
+        if (!definitions.containsKey(definition.id())) {
+            return Optional.empty();
+        }
+        List<UUID> uniquePlayers = new ArrayList<>(new java.util.LinkedHashSet<>(players));
+        int count = uniquePlayers.size();
+        if (count < definition.minPlayers() || count > definition.maxPlayers()) {
+            return Optional.empty();
+        }
+        String raidId = UUID.randomUUID().toString();
+        RaidInstance instance = new RaidInstance(raidId, definition, clock);
+        uniquePlayers.forEach(instance::addPlayer);
+        activeRaids.put(raidId, instance);
+        return Optional.of(instance);
+    }
+
+    public Optional<RaidInstance> getRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return Optional.ofNullable(activeRaids.get(raidId));
+    }
+
+    public List<RaidInstance> activeRaids() {
+        return List.copyOf(activeRaids.values());
+    }
+
+    public boolean endRaid(String raidId) {
+        Objects.requireNonNull(raidId, "raidId");
+        return activeRaids.remove(raidId) != null;
+    }
+
+    public Map<String, RaidDefinition> definitions() {
+        return definitions;
+    }
+}

--- a/src/main/java/com/raidextraction/stash/ItemData.java
+++ b/src/main/java/com/raidextraction/stash/ItemData.java
@@ -1,0 +1,26 @@
+package com.raidextraction.stash;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public record ItemData(String material, int amount, Map<String, String> tags) {
+    public ItemData {
+        Objects.requireNonNull(material, "material");
+        if (material.isBlank()) {
+            throw new IllegalArgumentException("material cannot be blank");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        if (tags == null) {
+            tags = Map.of();
+        }
+        tags = Collections.unmodifiableMap(new HashMap<>(tags));
+    }
+
+    public ItemData(String material, int amount) {
+        this(material, amount, Map.of());
+    }
+}

--- a/src/main/java/com/raidextraction/stash/SQLiteStashRepository.java
+++ b/src/main/java/com/raidextraction/stash/SQLiteStashRepository.java
@@ -1,0 +1,196 @@
+package com.raidextraction.stash;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public final class SQLiteStashRepository implements StashRepository {
+    private final String jdbcUrl;
+
+    public SQLiteStashRepository(Path databasePath) {
+        Objects.requireNonNull(databasePath, "databasePath");
+        this.jdbcUrl = "jdbc:sqlite:" + databasePath.toAbsolutePath();
+        ensureSchema();
+    }
+
+    @Override
+    public List<ItemData> loadStash(UUID ownerId) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        String sql = "SELECT slot, material, amount, tags FROM stash_items WHERE owner_uuid = ? ORDER BY slot ASC";
+        List<ItemData> items = new ArrayList<>();
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, ownerId.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String material = resultSet.getString("material");
+                    int amount = resultSet.getInt("amount");
+                    String tagsValue = resultSet.getString("tags");
+                    items.add(new ItemData(material, amount, deserializeTags(tagsValue)));
+                }
+            }
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to load stash for " + ownerId, error);
+        }
+        return Collections.unmodifiableList(items);
+    }
+
+    @Override
+    public void saveStash(UUID ownerId, List<ItemData> items) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        Objects.requireNonNull(items, "items");
+        String deleteSql = "DELETE FROM stash_items WHERE owner_uuid = ?";
+        String insertSql = "INSERT INTO stash_items (owner_uuid, slot, material, amount, tags) VALUES (?, ?, ?, ?, ?)";
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement deleteStatement = connection.prepareStatement(deleteSql)) {
+                deleteStatement.setString(1, ownerId.toString());
+                deleteStatement.executeUpdate();
+            }
+            try (PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
+                int slot = 0;
+                for (ItemData item : items) {
+                    insertStatement.setString(1, ownerId.toString());
+                    insertStatement.setInt(2, slot++);
+                    insertStatement.setString(3, item.material());
+                    insertStatement.setInt(4, item.amount());
+                    insertStatement.setString(5, serializeTags(item.tags()));
+                    insertStatement.addBatch();
+                }
+                insertStatement.executeBatch();
+            }
+            connection.commit();
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to save stash for " + ownerId, error);
+        }
+    }
+
+    @Override
+    public void clearStash(UUID ownerId) {
+        Objects.requireNonNull(ownerId, "ownerId");
+        String deleteSql = "DELETE FROM stash_items WHERE owner_uuid = ?";
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(deleteSql)) {
+            statement.setString(1, ownerId.toString());
+            statement.executeUpdate();
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to clear stash for " + ownerId, error);
+        }
+    }
+
+    private void ensureSchema() {
+        String sql = """
+                CREATE TABLE IF NOT EXISTS stash_items (
+                    owner_uuid TEXT NOT NULL,
+                    slot INTEGER NOT NULL,
+                    material TEXT NOT NULL,
+                    amount INTEGER NOT NULL,
+                    tags TEXT,
+                    PRIMARY KEY (owner_uuid, slot)
+                )
+                """;
+        try (Connection connection = openConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException error) {
+            throw new IllegalStateException("Failed to ensure stash schema", error);
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    private String serializeTags(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return "";
+        }
+        return tags.entrySet().stream()
+                .map(entry -> escape(entry.getKey()) + "=" + escape(entry.getValue()))
+                .collect(Collectors.joining(";"));
+    }
+
+    private Map<String, String> deserializeTags(String value) {
+        if (value == null || value.isBlank()) {
+            return Map.of();
+        }
+        Map<String, String> tags = new HashMap<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (escaping) {
+                current.append(character);
+                escaping = false;
+                continue;
+            }
+            if (character == '\\') {
+                escaping = true;
+                continue;
+            }
+            if (character == ';') {
+                addTagPair(tags, current.toString());
+                current.setLength(0);
+            } else {
+                current.append(character);
+            }
+        }
+        if (escaping) {
+            current.append('\\');
+        }
+        addTagPair(tags, current.toString());
+        return tags;
+    }
+
+    private void addTagPair(Map<String, String> tags, String rawPair) {
+        if (rawPair == null || rawPair.isEmpty()) {
+            return;
+        }
+        int index = rawPair.indexOf('=');
+        if (index < 0) {
+            tags.put(unescape(rawPair), "");
+            return;
+        }
+        String key = unescape(rawPair.substring(0, index));
+        String val = unescape(rawPair.substring(index + 1));
+        tags.put(key, val);
+    }
+
+    private String escape(String value) {
+        return value.replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace("=", "\\=");
+    }
+
+    private String unescape(String value) {
+        StringBuilder builder = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (escaping) {
+                builder.append(character);
+                escaping = false;
+            } else if (character == '\\') {
+                escaping = true;
+            } else {
+                builder.append(character);
+            }
+        }
+        if (escaping) {
+            builder.append('\\');
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/raidextraction/stash/StashRepository.java
+++ b/src/main/java/com/raidextraction/stash/StashRepository.java
@@ -1,0 +1,12 @@
+package com.raidextraction.stash;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StashRepository {
+    List<ItemData> loadStash(UUID ownerId);
+
+    void saveStash(UUID ownerId, List<ItemData> items);
+
+    void clearStash(UUID ownerId);
+}

--- a/src/main/java/com/raidextraction/stash/StashService.java
+++ b/src/main/java/com/raidextraction/stash/StashService.java
@@ -1,0 +1,43 @@
+package com.raidextraction.stash;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class StashService {
+    private final StashRepository repository;
+
+    public StashService(StashRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+    }
+
+    public List<ItemData> load(UUID ownerId) {
+        return repository.loadStash(ownerId);
+    }
+
+    public void replace(UUID ownerId, List<ItemData> items) {
+        repository.saveStash(ownerId, items);
+    }
+
+    public void clear(UUID ownerId) {
+        repository.clearStash(ownerId);
+    }
+
+    public void addItem(UUID ownerId, ItemData itemData) {
+        Objects.requireNonNull(itemData, "itemData");
+        List<ItemData> items = new ArrayList<>(repository.loadStash(ownerId));
+        items.add(itemData);
+        repository.saveStash(ownerId, items);
+    }
+
+    public boolean removeItem(UUID ownerId, ItemData itemData) {
+        Objects.requireNonNull(itemData, "itemData");
+        List<ItemData> items = new ArrayList<>(repository.loadStash(ownerId));
+        boolean removed = items.remove(itemData);
+        if (removed) {
+            repository.saveStash(ownerId, items);
+        }
+        return removed;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide player-facing command handlers and listener stubs to interact with the raid lifecycle and complete Phase 6 of the roadmap.  
- Wire core pure-logic services (queue, raid manager, loot registry/service, evac tracker, extraction service) into the plugin lifecycle so managers are available to commands and listeners.  
- Add neutral stash persistence and item representation to support storing extracted loot outside of Minecraft-specific types.  
- Make extraction countdowns deterministic and testable by using an injected `Clock` and record extraction idempotently per-raid.

### Description
- Initialize and wire services in `RaidExtractionPlugin` via new `initializeServices`, `registerCommands`, and `registerListeners` methods.  
- Add command handlers `RaidCommand`, `StashCommand`, and `RaidAdminCommand` and listener stubs `RaidListener` and `ExtractionListener`.  
- Implement core logic classes: `QueueManager`, `RaidManager`, `LootTableRegistry`, `LootService`, `EvacTracker`, `ExtractionService`, `ItemData`, `StashService`, `StashRepository`, and `SQLiteStashRepository` with tag serialization helpers.  
- Update `TODO.md` to mark Phase 6 complete.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609e37e6448331a85c188cc8bcdfd7)